### PR TITLE
improve loading page experience

### DIFF
--- a/src/game/game_static/client.css
+++ b/src/game/game_static/client.css
@@ -75,6 +75,7 @@ iframe {
 	margin-right: 1em;
 }
 
+.navigation-button,
 #restart {
 	margin: 0;
 	border-radius: 3em;
@@ -85,8 +86,14 @@ iframe {
 	margin-left: .5em;
 }
 
+.navigation-button:hover,
 #restart:hover {
 	background: lightgrey;
+}
+
+.navigation-button {
+	color: black;
+	text-decoration: none;
 }
 
 #goal,
@@ -162,4 +169,9 @@ li span {
 	width: fit-content;
 	min-width: fit-content;
 	margin-right: 1em;
+}
+
+#go-home {
+	display: none;
+	width: fit-content;
 }

--- a/src/game/game_static/client.js
+++ b/src/game/game_static/client.js
@@ -199,6 +199,8 @@ function setUpCountDown() {
 
 function startGame(level) {
 	const error = document.getElementById("error-text");
+	document.getElementById("container").style.display = "block"; // show navigation and controls
+	document.getElementById('go-home').style.display = "none"; // hide "go home button" that is shown when someone joins a level too early
 
 	// Set iframe url:
 	if (level !== undefined) {
@@ -226,9 +228,10 @@ function loadClient() {
 
 		// Update time on screen
 		if (minutes > 0) {
-			error.textContent = `Starts in ${minutes} minute${s(
+			error.innerHTML = `Starts in ${minutes} minute${s(
 				minutes
-			)} ${Math.round(seconds)} second${s(Math.round(seconds))}.`;
+			)} ${Math.round(seconds)} second${s(Math.round(seconds))}. `;
+			document.getElementById('go-home').style.display = "block";
 		} else {
 			const timeLeft = Math.round(seconds * 10) / 10;
 			error.innerHTML = `Starts in ${timeLeft} second${s(
@@ -236,8 +239,12 @@ function loadClient() {
 			)}. <br>	Goal: Go from <b>${serialize(
 				level.startPage
 			)}</b> to <b>${serialize(level.endPage)}</b><br><br>
-			Remember that the goal is displayed in the bottom right.`;
+			Remember that the goal is displayed in the top right.`;
+			document.getElementById('go-home').style.display = "none";
 		}
+
+		// Hide game controls
+		document.getElementById("container").style.display = "none";
 
 		// start game at correct time.
 		if (getTime() - startDate >= 0) {

--- a/src/game/index.html
+++ b/src/game/index.html
@@ -21,6 +21,7 @@
 
 	<body>
 		<div id="error-text"></div>
+		<a href="/wiki-races/" class="navigation-button" id="go-home"> Go Home </a>
 		<div id="container">
 			<div id="overlay">
 				<div id="control-buttons-frame">


### PR DESCRIPTION
Before:

The title bar showed up when it didn't really look good
![Screenshot from 2023-12-21 11-56-25](https://github.com/INTERallianceGC/WikiRaces/assets/46602241/5934d3c3-be5b-422f-b333-20776c84e175)


After:

Title bar is hidden until game starts:
![image](https://github.com/INTERallianceGC/WikiRaces/assets/46602241/4d699e3c-ae66-4c89-b28f-6bf89e519e75)

![image](https://github.com/INTERallianceGC/WikiRaces/assets/46602241/4ae596fd-d2ff-426f-b190-f4317260210a)


Plus, there is now a button when someone joins a game too early.

![image](https://github.com/INTERallianceGC/WikiRaces/assets/46602241/75d439f5-88fc-402a-9b44-1ca40153c381)
