### PR TITLE
fix disappearing nav

### DIFF
--- a/src/game/game_static/client.js
+++ b/src/game/game_static/client.js
@@ -186,6 +186,7 @@ function setUpCountDown() {
 		console.log(timer.textContent, "timer.textContent");
 		timer.textContent = getCountdownString();
 
+
 		// Update time on screen
 
 		// clear interval when time passes
@@ -195,6 +196,21 @@ function setUpCountDown() {
 			window.location.href = generateURL("/wiki-races/levelOver.html");
 		}
 	}, 200);
+
+	let fixWindowHack = setInterval(() => {
+		// TODO: This is a hack to keep the top navigation bar in view.
+		// Currently, when a user clicks a link to a document's subheading,
+		// it scrolls the page such that the top navigation is not in view.
+		// It may be possible to restyle the CSS such that the container floats
+		// on top, and can't scroll out of view. However, a quicker fix is to
+		// just scroll it into view.
+		const container = document.getElementById("container");
+		container.scrollIntoView();
+		// clear interval when time passes
+		if (getTime() - endDate >= 0) {
+			clearInterval(fixWindowHack);
+		}
+	}, 1000);
 }
 
 function startGame(level) {


### PR DESCRIPTION
This is a hack to keep the top navigation bar in view.

Currently, when a user clicks a link to a document's subheading, it scrolls the page such that the top navigation is not in view. It may be possible to restyle the CSS such that the container floats top, and can't scroll out of view. However, a quicker fix is to scroll it into view.

If I had infinite time and energy, I wouldn't ship this, but I've tested it and it's a decent functional fix.

Using `display: float` for the header would be much better, but I really don't feel like messing with CSS at the moment. ¯\\\_(ツ)_/¯